### PR TITLE
Add cleanup of old background images in account page

### DIFF
--- a/account/script.js
+++ b/account/script.js
@@ -74,9 +74,28 @@
 uploadButton.addEventListener('click', async () => {
     const file = backgroundUpload.files[0];
     if (file) {
-        const storageRef = firebase.storage().ref(`backgrounds/<span class="math-inline">\{userId\}/</span>{file.name}`);
-
         try {
+            // First, get the current background URL and delete it if it exists
+            const userProfileString = localStorage.getItem("USER_PROFILE");
+            if (userProfileString) {
+                const userProfileData = JSON.parse(userProfileString);
+                if (userProfileData.customBackgroundURL) {
+                    try {
+                        // Extract the path from the full URL
+                        const oldUrl = new URL(userProfileData.customBackgroundURL);
+                        const oldPath = decodeURIComponent(oldUrl.pathname.split('/o/')[1].split('?')[0]);
+                        const oldRef = firebase.storage().ref(oldPath);
+                        await oldRef.delete();
+                        console.log("Deleted old background");
+                    } catch (error) {
+                        console.warn("Error deleting old background:", error);
+                        // Continue even if delete fails
+                    }
+                }
+            }
+
+            // Upload the new file
+            const storageRef = firebase.storage().ref(`backgrounds/${userId}/${file.name}`);
             await storageRef.put(file);
             const downloadURL = await storageRef.getDownloadURL();
 


### PR DESCRIPTION
When users upload a new background image in their account page, the old image is now automatically deleted from Firebase Storage to prevent accumulation of unused files.

### Changes
- Added functionality to extract the storage path from existing background URLs
- Implemented cleanup of old background images before uploading new ones
- Added error handling for background deletion that allows upload to continue even if deletion fails
- Maintained existing upload and profile update functionality

### Testing
1. Upload a background image
2. Upload a different background image
3. Verify that the old image is deleted from Firebase Storage
4. Verify that the new image appears correctly



Created with [**Solver**](https://solverai.com)